### PR TITLE
convert host.json to 2.x format

### DIFF
--- a/dist/host.json
+++ b/dist/host.json
@@ -1,17 +1,20 @@
 {
-    "functionTimeout": "00:02:00",
-    "version": "2.0",
-    "extensionBundle": {
-      "id": "Microsoft.Azure.Functions.ExtensionBundle",
-      "version": "[2.*, 3.0.0)"
-    },
-    "eventHub": {
+  "functionTimeout": "00:02:00",
+  "version": "2.0",
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[2.*, 3.0.0)"
+  },
+  "extensions": {
+    "eventHubs": {
+      "batchCheckpointFrequency": 1,
+      "eventProcessorOptions": {
         "maxBatchSize": 64,
-        "prefetchCount": 256,
-        "batchCheckpointFrequency": 1
-    },
-    "functions": [
-        "logzioLogsFunction"
-    ]
-  }
-  
+        "prefetchCount": 256
+      }
+    }
+  },
+  "functions": [
+    "logzioLogsFunction"
+  ]
+}


### PR DESCRIPTION
Hello,
The current host.json is still using 1.x format. 
Because of this, the eventhub processor configuration is ignored and reverts to the azure defaults which are very small.

- maxBatchSize is 10
- prefetchCount is 300
- batchCheckpointFrequency is 1

Changing host.json file in its present form does not have any impact.