### PR TITLE
Extension Bundle version and tmp path fix

### DIFF
--- a/deployments/azuredeploylogs.json
+++ b/deployments/azuredeploylogs.json
@@ -176,7 +176,7 @@
                         },
                         {
                             "name": "FUNCTIONS_WORKER_PROCESS_COUNT",
-                            "value": "10"
+                            "value": "1"
                         },
                         {
                             "name": "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING",

--- a/dist/host.json
+++ b/dist/host.json
@@ -3,7 +3,7 @@
   "version": "2.0",
   "extensionBundle": {
     "id": "Microsoft.Azure.Functions.ExtensionBundle",
-    "version": "[2.*, 3.0.0)"
+    "version": "[3.3.0, 4.0.0)"
   },
   "extensions": {
     "eventHubs": {

--- a/dist/logzioLogsFunction/backup-container.js
+++ b/dist/logzioLogsFunction/backup-container.js
@@ -1,6 +1,7 @@
 const fs = require("fs");
 const util = require("util");
-const tempDir = "C:\\local\\Temp\\";
+const os = require("os");
+const tempDir = os.tmpdir();
 const root = process.cwd();
 
 const folderMaxSizeInMB = 10000;
@@ -68,16 +69,16 @@ class BackupContainer {
   }
 
   deleteDirectoriesRecursively(tempDir, context) {
-        fs.readdir(tempDir, function(err, items) {
-        context.log("About to delete all files in: ", tempDir)
-        for (var i=0; i<items.length; i++) {
-            if (items[i] != 'logzioLogsFunction'){
-                fs.rmdirSync(items[i], { recursive: true });
-            }
-        } 
-        context.log("Deleted successfully.")
+    fs.readdir(tempDir, function (err, items) {
+      context.log("About to delete all files in: ", tempDir)
+      for (var i = 0; i < items.length; i++) {
+        if (items[i] != 'logzioLogsFunction') {
+          fs.rmdirSync(items[i], { recursive: true });
+        }
+      }
+      context.log("Deleted successfully.")
     });
-   }
+  }
 
   async uploadFiles() {
     try {
@@ -109,7 +110,7 @@ class BackupContainer {
       if (!this._filesToUpload.includes(fileFullPath)) {
         this._filesToUpload.push(fileFullPath);
       }
-    } 
+    }
     catch (error) {
       this._context.log.error(`Error was thrown in appendFile, ${error}`);
     }


### PR DESCRIPTION
ExtensionBundle version was configured for 2.x which uses v4 of the eventhub libraries. Switching to 3.x to get version 5 which fixes an error about casting issue 

The tmp fix is required because the temp storage can be either on C or D drive, since it was hardcoded, it failed on many function instances to create the tmp dir for blob storage.

I've also included a change for "FUNCTIONS_WORKER_PROCESS_COUNT" to use the default value of 1 since this seems to create a lot of chaos in our deployments.
Having each function invocation with a single process count and letting azure handle the number of instances based on the triggers load seem to give a much smoother experience.



