### PR TITLE
v2.0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ You'll have the option to edit the following values:
 
 
 ## Changelog
+- 2.0.6:
+- Update `@azure/storage-blob` -> 12.12.0
+- Update `extensionBundle` version `[3.3.0, 4.0.0)` -> `[4.0.0, 5.0.0)`
 - 2.0.5:
   * Update `FUNCTIONS_EXTENSION_VERSION`: `~3` -> `~4`
   * Update NodeJS `12` -> `16`

--- a/dist/host.json
+++ b/dist/host.json
@@ -3,7 +3,7 @@
   "version": "2.0",
   "extensionBundle": {
     "id": "Microsoft.Azure.Functions.ExtensionBundle",
-    "version": "[3.3.0, 4.0.0)"
+    "version": "[4.0.0, 5.0.0)"
   },
   "extensions": {
     "eventHubs": {

--- a/dist/package.json
+++ b/dist/package.json
@@ -12,7 +12,7 @@
   ],
   "license": "ISC",
   "dependencies": {
-    "@azure/storage-blob": "^12.2.1",
+    "@azure/storage-blob": "^12.12.0",
     "logzio-nodejs": "^2.0.3"
   }
 }


### PR DESCRIPTION
Whats new:
- Update `@azure/storage-blob` -> 12.12.0
- Update `extensionBundle` version `[3.3.0, 4.0.0)` -> `[4.0.0, 5.0.0)`
Why:
We have a customer that is facing timeout errors with his function deployment, they are also getting `Did not find any initialized language workers` exceptions, I suspect that it might have something do to with using npm an old npm package (from 2.5 years ago)